### PR TITLE
fix: Pass query params trough pagination

### DIFF
--- a/app/helpers/pagy_helper.rb
+++ b/app/helpers/pagy_helper.rb
@@ -1,9 +1,11 @@
 module PagyHelper
-  def pagy_nav_link(label, page, aria_label, path_helper)
+  def pagy_nav_link(label:, page:, aria_label:, path_helper:, rel:)
+    options = { role: "button", "aria-label": aria_label, rel: rel }
+
     if page
-      link_to label, path_helper.call(page), aria_label: aria_label, aria_disabled: false, role: "button"
+      link_to label, path_helper.call(page), **options.merge("aria-disabled": false)
     else
-      link_to label, "javascript:void(0)", aria_label: aria_label, aria_disabled: true, role: "button", disabled: true
+      link_to label, "javascript:void(0)", **options.merge("aria-disabled": true, disabled: true)
     end
   end
 end

--- a/app/views/boardgames/_search_form.html.erb
+++ b/app/views/boardgames/_search_form.html.erb
@@ -2,6 +2,6 @@
   <%= form.label :q, t(".label") %>
   <%= fieldset_tag nil, "role" => "group" do %>
     <%= form.text_field :q, placeholder: t(".placeholder") %>
-    <%= form.submit t(".submit") %>
+    <%= form.submit t(".submit"), name: nil %>
   <% end %>
 <% end %>

--- a/app/views/boardgames/index.html.erb
+++ b/app/views/boardgames/index.html.erb
@@ -17,5 +17,5 @@
       <%= render 'card', boardgame: %>
     <% end %>
   </div>
-  <%= render 'shared/pagination', pagy: @pagy, path_helper: ->(p) { boardgames_path(page: p) } %>
+  <%= render 'shared/pagination', pagy: @pagy, path_helper: ->(p) { boardgames_path(params.permit(:q,:page).merge(page: p)) } %>
 </section>

--- a/app/views/shared/_pagination.html.erb
+++ b/app/views/shared/_pagination.html.erb
@@ -1,8 +1,8 @@
 
 <%# source: https://ddnexus.github.io/pagy/docs/how-to/#using-your-pagination-templates %>
 <nav class="pagy nav grid" aria-label=<%= t(".aria_label.nav") %>>
-  <%= pagy_nav_link(t(".prev_html"), pagy.prev, t(".aria_label.prev"), path_helper) %>
-  <%= pagy_nav_link(t(".next_html"), pagy.next, t(".aria_label.next"), path_helper) %>
+  <%= pagy_nav_link(label: t(".prev_html"), page: pagy.prev, aria_label: t(".aria_label.prev"), path_helper: path_helper, rel: "prev") %>
+  <%= pagy_nav_link(label: t(".next_html"), page: pagy.next, aria_label: t(".aria_label.next"), path_helper: path_helper, rel: "next") %>
 </nav>
 
 


### PR DESCRIPTION
Fixes the pagination issue where the query param would be lost after clicking the next or prev page links.