### PR TITLE
Outbound links

### DIFF
--- a/app/controllers/boardgames_controller.rb
+++ b/app/controllers/boardgames_controller.rb
@@ -34,6 +34,7 @@ class BoardgamesController < ApplicationController
       .select(
         "listings.url",
         "listings.title",
+        "stores.id AS store_id",
         "stores.name AS store_name",
         "MIN(prices_today.amount) AS best_price"
       )

--- a/app/helpers/external_link_helper.rb
+++ b/app/helpers/external_link_helper.rb
@@ -1,8 +1,33 @@
 module ExternalLinkHelper
+  UTM_PARAMS = {
+    utm_source: "turnoextra",
+    utm_medium: "referral",
+    utm_campaign: "outbound_click"
+  }.freeze
+
   def safe_url(url)
     uri = URI.parse(url)
     uri.is_a?(URI::HTTP) ? uri.to_s : nil
   rescue URI::InvalidURIError
     nil
+  end
+
+  def tracking_url(url)
+    base_url = safe_url(url)
+    return nil unless base_url
+
+    uri = URI.parse(base_url)
+    query = Rack::Utils.parse_nested_query(uri.query).merge(UTM_PARAMS)
+    uri.query = Rack::Utils.build_query(query)
+    uri.to_s
+  end
+
+  def umami_event_attributes(name, properties = {})
+    return {} unless name.present?
+
+    attrs = { "data-umami-event" => name }
+    properties.each_with_object(attrs) do |(key, value), hash|
+      hash["data-umami-event-#{key}"] = value.to_s
+    end
   end
 end

--- a/app/views/boardgames/show.html.erb
+++ b/app/views/boardgames/show.html.erb
@@ -32,7 +32,15 @@
     <tbody>
       <% @listings.each do |listing| %>
         <tr>
-          <td><%= link_to listing.title, listing.url %></td>
+          <td><%= link_to listing.title,
+            tracking_url(listing.url),
+            target: "_blank",
+            rel: "noopener",
+            **umami_event_attributes("outbound_boardgames_show_click", {
+              store_id: listing.store_id,
+              listing_id: listing.id,
+              boardgame_id: @boardgame.id
+            }) %></td>
           <td><%= format_price(listing.best_price) %></td>
           <td><%= listing.store_name %></td>
         </tr>

--- a/app/views/stores/index.html.erb
+++ b/app/views/stores/index.html.erb
@@ -16,7 +16,13 @@
       <% @stores.each do |store| %>
         <tr>
           <td><%= store.name %></td>
-          <td><%= link_to t(".external_link"), safe_url(store.url) %></td>
+          <td><%= link_to t(".external_link"),
+            tracking_url(store.url),
+            target: "_blank",
+            rel: "noopener",
+            **umami_event_attributes("outbound_stores_index_click", {
+              store_id: store.id
+            }) %></td>
         </tr>
       <% end %>
     </tbody>


### PR DESCRIPTION
Fixes brakeman's link_to warnings by parsing the urls with URI and checking for HTTP or HTTPS schemes.

It wouldn't protect against forged parameters, but decent enough (according to brakeman rules) to render them in the views.

Also took the chance to add UTM tags and umami data tags for outbound clicks tracking.